### PR TITLE
move use_dynamic_adjustment to query model

### DIFF
--- a/src/app/models/query.model.ts
+++ b/src/app/models/query.model.ts
@@ -29,6 +29,7 @@ export interface IQuery {
   notes: string;
   reference_clip_image: string;
   search_set_to_query: number;
+  use_dynamic_target_adjustment: boolean;
   video: number;
   process_state: ProcessState;
 }

--- a/src/app/models/search-set.model.ts
+++ b/src/app/models/search-set.model.ts
@@ -9,7 +9,6 @@ export interface ISearchSet  {
   id: number;
   name: string;
   duration: number;
-  useDynamicTargetAdjustment: boolean;
 
   /**
    * Collection of FKs

--- a/src/app/pages/admin/search-set-add/components/current/current.component.html
+++ b/src/app/pages/admin/search-set-add/components/current/current.component.html
@@ -35,17 +35,6 @@
         </div>
       </div>
     </div>
-    <br>
-    <div class="custom-control custom-checkbox">
-      <div class="form-group">
-        <input type="checkbox" class="custom-control-input" id="searchSetDynamic" [(ngModel)]="searchSetAddService.searchSet.useDynamicTargetAdjustment"
-          name="searchSetDynamic">
-        <label class="custom-control-label">Dynamic target adjustment</label>&nbsp;
-        <i matTooltip="Let the algorithms know whether to “average” the features of all validated matches in each round and have that become the new target.
-                       If not selected, the reference clip remains the target in each round."
-          class="vq-info-tooltip fa fa-question"></i>
-      </div>
-    </div>
   </form>
   <hr>
   <table>

--- a/src/app/pages/admin/search-set-add/search-set-add.component.ts
+++ b/src/app/pages/admin/search-set-add/search-set-add.component.ts
@@ -54,15 +54,12 @@ export class SearchSetAddComponent implements OnInit {
     }
 
     this.searchSetAddService.addSearchSet()
-      .then((resp) => {
+      .then(() => {
         this.loading = false;
         this.alertService.setAlert(
           `"${this.searchSetAddService.searchSet.name}": has been added.`,
           AlertType.Success
         );
-        this.searchSetAddService.searchSet = {
-          videos: [] // Collection of keys
-        } as ISearchSet;
         this.router.navigate(['search-sets']);
       })
       .catch((message: string) => {

--- a/src/app/pages/admin/search-set-add/search-set-add.component.ts
+++ b/src/app/pages/admin/search-set-add/search-set-add.component.ts
@@ -3,6 +3,7 @@ import { SearchSetAddService } from './services/search-set-add.service';
 import { ModalComponent } from '../../../components/modal/modal.component';
 import { Router } from '@angular/router';
 import { AlertService, AlertType } from '../../../services/alert.service';
+import { ISearchSet } from '../../../models/search-set.model';
 
 @Component({
   selector: 'app-search-set-add',
@@ -59,6 +60,9 @@ export class SearchSetAddComponent implements OnInit {
           `"${this.searchSetAddService.searchSet.name}": has been added.`,
           AlertType.Success
         );
+        this.searchSetAddService.searchSet = {
+          videos: [] // Collection of keys
+        } as ISearchSet;
         this.router.navigate(['search-sets']);
       })
       .catch((message: string) => {

--- a/src/app/pages/admin/search-set-add/services/search-set-add.service.ts
+++ b/src/app/pages/admin/search-set-add/services/search-set-add.service.ts
@@ -15,7 +15,6 @@ export class SearchSetAddService {
    * New Search Set
    */
   searchSet = {
-    useDynamicTargetAdjustment: false,
     videos: [] // Collection of keys
   } as ISearchSet;
 
@@ -81,10 +80,9 @@ export class SearchSetAddService {
       .toPromise()
       .then(() => {
         this.videosInSearchSet = [];
-        this.searchSet = {
-          useDynamicTargetAdjustment: false,
+        /* this.searchSet = {
           videos: [] // Collection of keys
-        } as ISearchSet;
+        } as ISearchSet; */
       })
       .catch((resp: HttpErrorResponse) => {
         if (resp.error['name']) {

--- a/src/app/pages/admin/search-set-add/services/search-set-add.service.ts
+++ b/src/app/pages/admin/search-set-add/services/search-set-add.service.ts
@@ -80,9 +80,9 @@ export class SearchSetAddService {
       .toPromise()
       .then(() => {
         this.videosInSearchSet = [];
-        /* this.searchSet = {
+        this.searchSet = {
           videos: [] // Collection of keys
-        } as ISearchSet; */
+        } as ISearchSet;
       })
       .catch((resp: HttpErrorResponse) => {
         if (resp.error['name']) {

--- a/src/app/pages/admin/search-set/search-set.component.html
+++ b/src/app/pages/admin/search-set/search-set.component.html
@@ -23,17 +23,6 @@
               <li>
                 <b>Clip Duration (s): </b>{{searchSetService.searchSet?.duration}}
               </li>
-              <li>
-                <b>Use Dynamic Target Adjustment (
-                  <i matTooltip="When selected, the target will be updated in each round by setting it equal to
-                                 an average over all validated matches. When not selected, the reference clip will
-                                 remain the target in all query rounds."
-                    class="vq-info-tooltip fa fa-question">
-                  </i>
-                  ):
-                </b>
-                {{searchSetService.searchSet?.useDynamicTargetAdjustment ? 'Yes': 'No'}}
-              </li>
             </ul>
             <div class="vq-widget">
               <p class="lead">Videos in Search Set</p>

--- a/src/app/pages/existing-query/components/query-header/query-header.component.html
+++ b/src/app/pages/existing-query/components/query-header/query-header.component.html
@@ -34,6 +34,9 @@
             <span class="font-weight-bold">Clip duration: </span>{{query?.search_set_to_query_object?.duration}} s
           </li>
           <li>
+            <span class="font-weight-bold">Dynamic target adjustment: </span>{{query?.use_dynamic_target_adjustment}}
+          </li>
+          <li>
             <span class="font-weight-bold">
               Matches to review (
               <i matTooltip="Maximum number of matches the user wants to review for this query.

--- a/src/app/pages/existing-query/components/query-header/query-header.component.scss
+++ b/src/app/pages/existing-query/components/query-header/query-header.component.scss
@@ -7,5 +7,5 @@ ul {
 }
 
 textarea {
-    height: 96px;
+    height: 108px;
 }

--- a/src/app/pages/new-query/new-query.component.html
+++ b/src/app/pages/new-query/new-query.component.html
@@ -86,33 +86,15 @@
                 </div>
               </div>
             </div>
-
             <div class="form-group custom-control custom-checkbox">
-              <!-- Default unchecked for use_dynamic_target_adjustment -->
-              <input type="checkbox" class="custom-control-input" id="defaultUnchecked"
-                     [(ngModel)]="newQueryService.form.use_dynamic_target_adjustment"
-                     name="queryDynamic">
+              <input type="checkbox" class="custom-control-input" id="defaultUnchecked" [(ngModel)]="newQueryService.form.use_dynamic_target_adjustment"
+                name="queryDynamic">
               <label class="custom-control-label" for="defaultUnchecked"> Dynamic target adjustment
-                (
                 <i matTooltip="Let the algorithms know whether to “average” the features of all validated matches in each round and have that become the new target.
-                               If not selected, the reference clip remains the target in each round."
-                   class="vq-info-tooltip fa fa-question">
+                               If not selected, the reference clip remains the target in each round." class="vq-info-tooltip fa fa-question">
                 </i>
-                )
               </label>
-
             </div>
-            <!--<div class="form-group">
-                <b>Use Dynamic Target Adjustment (
-                  <i matTooltip="When selected, the target will be updated in each round by setting it equal to
-                                 an average over all validated matches. When not selected, the reference clip will
-                                 remain the target in all query rounds."
-                    class="vq-info-tooltip fa fa-question">
-                  </i>
-                  ):
-                </b>
-                {{newQueryService.searchSet?.use_dynamic_target_adjustment ? 'Yes': 'No'}}
-            </div> -->
           </fieldset>
           <div class="form-group">
             <label for="name">Query name:</label>

--- a/src/app/pages/new-query/new-query.component.html
+++ b/src/app/pages/new-query/new-query.component.html
@@ -86,6 +86,33 @@
                 </div>
               </div>
             </div>
+
+            <div class="form-group custom-control custom-checkbox">
+              <!-- Default unchecked for use_dynamic_target_adjustment -->
+              <input type="checkbox" class="custom-control-input" id="defaultUnchecked"
+                     [(ngModel)]="newQueryService.form.use_dynamic_target_adjustment"
+                     name="queryDynamic">
+              <label class="custom-control-label" for="defaultUnchecked"> Dynamic target adjustment
+                (
+                <i matTooltip="Let the algorithms know whether to “average” the features of all validated matches in each round and have that become the new target.
+                               If not selected, the reference clip remains the target in each round."
+                   class="vq-info-tooltip fa fa-question">
+                </i>
+                )
+              </label>
+
+            </div>
+            <!--<div class="form-group">
+                <b>Use Dynamic Target Adjustment (
+                  <i matTooltip="When selected, the target will be updated in each round by setting it equal to
+                                 an average over all validated matches. When not selected, the reference clip will
+                                 remain the target in all query rounds."
+                    class="vq-info-tooltip fa fa-question">
+                  </i>
+                  ):
+                </b>
+                {{newQueryService.searchSet?.use_dynamic_target_adjustment ? 'Yes': 'No'}}
+            </div> -->
           </fieldset>
           <div class="form-group">
             <label for="name">Query name:</label>

--- a/src/app/pages/new-query/new-query.service.ts
+++ b/src/app/pages/new-query/new-query.service.ts
@@ -26,7 +26,8 @@ export class NewQueryService {
     reference_time_seconds: 0,
     reference_time_hours: 0,
     reference_time_minutes: 0,
-    max_matches_for_review: 10
+    max_matches_for_review: 10,
+    use_dynamic_target_adjustment: false
   } as IQueryForm;
 
   constructor(


### PR DESCRIPTION
Also, fix problem with new search set name not showing in banner after saving it. ("undefined" was showing up instead)

After thinking about it, I feel whether or not to use dynamic adjustment in the query rounds seems like it belongs in the query model, not the search set model.
