### PR TITLE
remove display of loading variable on new query page

### DIFF
--- a/src/app/pages/new-query/new-query.component.html
+++ b/src/app/pages/new-query/new-query.component.html
@@ -173,6 +173,5 @@
       </div>
     </div>
   </div>
-  {{loading}}
   <app-loader [show]="loading"></app-loader>
 </section>


### PR DESCRIPTION
somehow I did not commit this change.  It is that display of "false" in the bottom left of the new query page