### PR TITLE
set user_match to null when user clicks "Remove", so the value of use…

### DIFF
--- a/src/app/pages/existing-query/charts/reference-video/reference-video.component.html
+++ b/src/app/pages/existing-query/charts/reference-video/reference-video.component.html
@@ -28,7 +28,7 @@
       </div>
       <div class="col-sm">
         <button type="button" [disabled]="isEditable || !matchService.videoSrc || this.loading || existingQueryService.disabled || matchService.getActiveMatch()?.user_match === null" class="btn btn-block btn-secondary"
-          (click)="onValidationClicked()">Remove</button>
+          (click)="onValidationClicked(null)">Remove</button>
       </div>
     </div>
   </div>

--- a/src/app/pages/existing-query/components/query-header/query-header.component.html
+++ b/src/app/pages/existing-query/components/query-header/query-header.component.html
@@ -34,16 +34,16 @@
             <span class="font-weight-bold">Clip duration: </span>{{query?.search_set_to_query_object?.duration}} s
           </li>
           <li>
-            <span class="font-weight-bold">Dynamic target adjustment: </span>{{query?.use_dynamic_target_adjustment}}
+            <span class="font-weight-bold">Target bootstrapping: </span>{{query?.use_dynamic_target_adjustment}}
           </li>
           <li>
             <span class="font-weight-bold">
-              Matches to review (
+              Matches to review
               <i matTooltip="Maximum number of matches the user wants to review for this query.
               The app will select a random sampling of matches and near matches
               that does not exceed this number. "
               class="vq-info-tooltip fa fa-question"></i>
-              ):
+              :
             </span>{{query?.max_matches_for_review}}
           </li>
         </ul>

--- a/src/app/pages/new-query/new-query.component.html
+++ b/src/app/pages/new-query/new-query.component.html
@@ -89,7 +89,7 @@
             <div class="form-group custom-control custom-checkbox">
               <input type="checkbox" class="custom-control-input" id="defaultUnchecked" [(ngModel)]="newQueryService.form.use_dynamic_target_adjustment"
                 name="queryDynamic">
-              <label class="custom-control-label" for="defaultUnchecked"> Dynamic target adjustment
+              <label class="custom-control-label" for="defaultUnchecked"> Target bootstrapping
                 <i matTooltip="Let the algorithms know whether to “average” the features of all validated matches in each round and have that become the new target.
                                If not selected, the reference clip remains the target in each round." class="vq-info-tooltip fa fa-question">
                 </i>


### PR DESCRIPTION
…r_match is changed to null in the db.

Change UI wording of "Dynamic Target Adjustment" to "Target Bootstrapping" -this seems like more clear wording to me. No change to API or algorithms.
Minor editing